### PR TITLE
Fix out-of-date docs for `or` function

### DIFF
--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -169,10 +169,10 @@ prev =
 positive (`Just`). However, unlike with `||`, both values will be
 computed anyway (there is no short-circuiting).
 
-    Just 4 `or` Just 5    == Just 4
-    Just 4 `or` Nothing   == Just 4
-    Nothing `or` Just 5   == Just 5
-    Nothing `or` Nothing  == Nothing
+    or (Just 4) (Just 5) == Just 4
+    or (Just 4) Nothing  == Just 4
+    or Nothing (Just 5)  == Just 5
+    or Nothing Nothing   == Nothing
 
 This function sort of works like `oneOf` but on single `Maybe`s.
 

--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -174,8 +174,6 @@ computed anyway (there is no short-circuiting).
     or Nothing (Just 5)  == Just 5
     or Nothing Nothing   == Nothing
 
-This function sort of works like `oneOf` but on single `Maybe`s.
-
 Advanced functional programmers will recognize this as the
 implementation of `mplus` for `Maybe`s from the `MonadPlus` type
 class.


### PR DESCRIPTION
* Removes infix notation from `or` docs. (Issue #28)
* Removes reference to `Maybe.oneOf` from `or` docs. (Issue #27)