### PR TITLE
oneOf

### DIFF
--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -5,11 +5,11 @@ module Maybe.Extra
         , combine
         , combineArray
         , filter
+        , firstJust
         , isJust
         , isNothing
         , join
         , next
-        , oneOf
         , or
         , orElse
         , orElseLazy
@@ -44,7 +44,7 @@ module Maybe.Extra
 
 # List and array functions
 
-@docs toList, toArray, traverse, combine, traverseArray, combineArray, values, oneOf
+@docs toList, toArray, traverse, combine, traverseArray, combineArray, values, firstJust
 
 -}
 
@@ -384,21 +384,13 @@ foldrValues item list =
 
 {-| Get the first `Just a` in a `List` of `Maybe a`.
 
-    oneOf [ Just 4, Just 5 ] == Just 4
-    oneOf [ Just 4, Nothing ] == Nothing
-    oneOf [ Nothing, Just 5 ] == Just 5
-    oneOf [ Nothing, Nothing ] == Nothing
-    oneOf [] == Nothing
+    firstJust [ Just 4, Just 5 ] == Just 4
+    firstJust [ Just 4, Nothing ] == Nothing
+    firstJust [ Nothing, Just 5 ] == Just 5
+    firstJust [ Nothing, Nothing ] == Nothing
+    firstJust [] == Nothing
 
 -}
-oneOf : List (Maybe a) -> Maybe a
-oneOf maybes =
-    case maybes of
-        (Just a) :: _ ->
-            Just a
-
-        Nothing :: rest ->
-            oneOf rest
-
-        [] ->
-            Nothing
+firstJust : List (Maybe a) -> Maybe a
+firstJust =
+    List.foldr or Nothing


### PR DESCRIPTION
Heres a function I used in a project at work recently, I thought could be a good addition to this repo. it takes a list of `Maybe` and returns the first `Just` if any of them are `Just`.

I think we've used it in a few places, but one of them is during routing. We have two methods of parsing a url. If either of them succeed, they will return a `Just Route`. We want to succeed if either of them work, and we arent picky about which one. 

I cant find the code now, but I think we also wanted to use it in a case where we want to provide a summary of some user data, which has many optional fields. So if any of the data exists, we display just the priority one, if none of the data exists, we display something different entirely.

Also, my elm-format made lots of little formatting changes to this repo. Sorry.