### PR TITLE
oneOf : List (a -> Maybe b) -> a -> Maybe b

### DIFF
--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -6,7 +6,7 @@ module Maybe.Extra exposing
     , combine, traverse, combineArray, traverseArray
     , toList, toArray
     , cons
-    , andMap, next, prev
+    , andMap, next, prev, oneOf
     )
 
 {-| Convenience functions for [`Maybe`](https://package.elm-lang.org/packages/elm/core/latest/Maybe).
@@ -45,7 +45,7 @@ Take the first value that's present
 
 # Applicative Functions
 
-@docs andMap, next, prev
+@docs andMap, next, prev, oneOf
 
 -}
 
@@ -549,3 +549,34 @@ Advanced functional programmers will recognize this as the implementation of `<*
 prev : Maybe a -> Maybe b -> Maybe a
 prev =
     map2 always
+
+
+{-| Try a list of functions against a value. Return the value of the first call that succeeds (returns `Just`).
+
+    type UserInput
+        = FloatInput Float
+        | IntInput Int
+        | UnknownInput
+
+    "5.6"
+        |> oneOf
+            [ String.toInt >> Maybe.map IntInput
+            , String.toFloat >> Maybe.map FloatInput
+            ]
+        |> Maybe.withDefault UnknownInput
+    --> FloatInput 5.6
+
+-}
+oneOf : List (a -> Maybe b) -> a -> Maybe b
+oneOf fmbs a =
+    case fmbs of
+        [] ->
+            Nothing
+
+        fmb :: rest ->
+            case fmb a of
+                Just b ->
+                    Just b
+
+                Nothing ->
+                    oneOf rest a

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -124,4 +124,23 @@ suite =
                         |> combineArray
                         |> Expect.equal Nothing
             ]
+        , describe "oneOf"
+            [ test "empty" <|
+                \() ->
+                    oneOf [] 0
+                        |> Expect.equal Nothing
+            , test "all fail" <|
+                \() ->
+                    oneOf (List.repeat 10 (always Nothing)) 0
+                        |> Expect.equal Nothing
+            , test "last function succeeds" <|
+                \() ->
+                    oneOf [ always Nothing, always Nothing, always Nothing, always (Just True) ] 0
+                        |> Expect.equal (Just True)
+            , test "first function succeeds" <|
+                \() ->
+                    0
+                        |> oneOf [ Just, Just << (+) 10, Just << (+) 20 ]
+                        |> Expect.equal (Just 0)
+            ]
         ]


### PR DESCRIPTION
As discussed on #46, adds `oneOf` function.

I've tried to match the variable naming style of other functions, and add sufficient tests.

@showell and I think it would be a worthwhile addition to this package, but happy to receive other feedback!

P.S. I added it to the applicative functions section in the docs, because I think that might be right 🤷‍♂, but school me if not