### PR TITLE
[#51] Fix License Discrepency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ Preview the docs with [elm-doc-preview](https://github.com/dmy/elm-doc-preview)
 
 ## License
 
-The source code for this package is released under the terms of the BSD3
+The source code for this package is released under the terms of the MIT
 license. See the `LICENSE` file.


### PR DESCRIPTION
Change the package's License specified in the README to MIT, since this
is what the original commit for the repository stated, as well as the
elm.json & LICENSE file.

Closes #51