### PR TITLE
Faster filter

### DIFF
--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -149,11 +149,15 @@ join mx =
 -}
 filter : (a -> Bool) -> Maybe a -> Maybe a
 filter f m =
-    case Maybe.map f m of
-        Just True ->
-            m
+    case m of
+        Just a ->
+            if f a then
+                m
 
-        _ ->
+            else
+                Nothing
+
+        Nothing ->
             Nothing
 
 


### PR DESCRIPTION
This improves the performance of the `filter` function.

The main change is that we don't call `Maybe.map f`, which removes some wrapping and unwrapping of the value. With it, we are in practice doing 2 pattern matching (one in this function and one in Maybe.map), plus wrapping the value in a `Just` inside the `Maybe.map`.

In this proposed version, these operations are removed compared to the original version.

Here is a benchmark: https://ellie-app.com/fCC677f4YLKa1

![Screenshot 2021-10-20 at 13 23 29](https://user-images.githubusercontent.com/3869412/138091503-321050a0-362b-46b8-91d4-3749d08e648f.png)

(Note and if you're interested: This is similar-ish to the PR I made for `Result.Extra.filter` https://github.com/elm-community/result-extra/pull/31 )