### PR TITLE
Make combine faster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -239,7 +239,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1069,9 +1068,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }

--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -447,8 +447,23 @@ If there are any `Nothing`s, the whole function fails and returns `Nothing`.
 
 -}
 combine : List (Maybe a) -> Maybe (List a)
-combine =
-    List.foldr (map2 (::)) (Just [])
+combine list =
+    combineHelp list []
+
+
+combineHelp : List (Maybe a) -> List a -> Maybe (List a)
+combineHelp list acc =
+    case list of
+        head :: tail ->
+            case head of
+                Just a ->
+                    combineHelp tail (a :: acc)
+
+                Nothing ->
+                    Nothing
+
+        [] ->
+            Just (List.reverse acc)
 
 
 {-| Like [`combine`](#combine), but map a function over each element of the list first.


### PR DESCRIPTION
This PR makes `Maybe.Extra.combine` a lot faster. I have described the approach and the benefits in an extremely similar PR for [`Result.Extra.combine`](https://github.com/elm-community/result-extra/pull/29). But in summary, we avoid a lot of unnecessary wrapping and unwrapping. The biggest gain is that if a value in the list is `Nothing`, we stop right there, instead of looping over the entire list even more.

I made a [benchmark](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/MaybeExtra/Combine.elm) for this change, and here are the results on Chrome:

![](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/MaybeExtra/Combine-Results-Chrome.png?raw=true)