### PR TITLE
Make traverse faster

### DIFF
--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -466,8 +466,23 @@ If any function call fails (returns `Nothing`), `traverse` will return `Nothing`
 
 -}
 traverse : (a -> Maybe b) -> List a -> Maybe (List b)
-traverse f =
-    List.foldr (\x -> map2 (::) (f x)) (Just [])
+traverse f list =
+    traverseHelp f list []
+
+
+traverseHelp : (a -> Maybe b) -> List a -> List b -> Maybe (List b)
+traverseHelp f list acc =
+    case list of
+        head :: tail ->
+            case f head of
+                Just a ->
+                    traverseHelp f tail (a :: acc)
+
+                Nothing ->
+                    Nothing
+
+        [] ->
+            Just (List.reverse acc)
 
 
 {-| Like [`combine`](#combine),


### PR DESCRIPTION
Makes `Maybe.Extra.traverse` faster.

This is very similar to #72. Here are the results of the [benchmark](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/MaybeExtra/Traverse.elm) I made for it:
 
![Screenshot from 2021-12-05 15-55-02](https://user-images.githubusercontent.com/3869412/144752199-83574a63-788c-4ae9-bd2f-f907f235f4db.png)

