### PR TITLE
Make prev and next faster

### DIFF
--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -698,8 +698,13 @@ Advanced functional programmers will recognize this as the implementation of `*>
 
 -}
 next : Maybe a -> Maybe b -> Maybe b
-next =
-    map2 (\b a -> always a b)
+next a b =
+    case a of
+        Nothing ->
+            Nothing
+
+        Just _ ->
+            b
 
 
 {-| Take two `Maybe` values. If the second one equals `Nothing`, return `Nothing`. Otherwise return the first value.
@@ -717,5 +722,10 @@ Advanced functional programmers will recognize this as the implementation of `<*
 
 -}
 prev : Maybe a -> Maybe b -> Maybe a
-prev =
-    map2 always
+prev a b =
+    case b of
+        Nothing ->
+            Nothing
+
+        Just _ ->
+            a


### PR DESCRIPTION
These implementations have the same behavior as the previous implementations, but avoid unnecessarily pattern matching on the returned maybe (which is what `map2` does under the hood).

I could have done a similar implementation using `next a b = map (always b) a` (and similar for `prev`) which is a lot closer in terms of performance, but I prefer my version which is I believe easier to read (and is also slightly faster).

## Next
[Benchmark](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/MaybeExtra/Next.elm)

![](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/MaybeExtra/Next-Results-Chrome.png?raw=true)

## Prev


[Benchmark](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/MaybeExtra/Prev.elm)

![](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/MaybeExtra/Prev-Results-Chrome.png?raw=true)